### PR TITLE
refactor: add better CVR types

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -123,6 +123,14 @@ export interface FullElectionTally {
   overallTally: ElectionTally
 }
 
+// Cast Vote Record
+
+export interface CastVoteRecord extends Dictionary<string | string[]> {
+  _precinctId: string
+  _ballotId: string
+  _ballotStyleId: string
+}
+
 // Smart Card Content
 export type CardDataTypes = 'voter' | 'pollworker' | 'clerk'
 export interface CardData {

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -1,0 +1,31 @@
+/**
+ * Finds an element in `array` that matches `predicate`, optionally returning
+ * `defaultValue` if no element matches.
+ *
+ * @throws when no element matches and no default value is provided
+ */
+function find<T>(array: T[], predicate: (element: T) => boolean): T
+function find<T>(
+  array: T[],
+  predicate: (element: T) => boolean,
+  defaultValue: T
+): T
+function find<T>(
+  array: T[],
+  predicate: (element: T) => boolean,
+  defaultValue?: T
+): T {
+  const result = array.find(predicate)
+
+  if (result === undefined) {
+    if (defaultValue === undefined) {
+      throw new Error('unable to find an element matching a predicate')
+    }
+
+    return defaultValue
+  }
+
+  return result
+}
+
+export default find


### PR DESCRIPTION
Includes renamed `_serialNumber` as `_ballotId`.