### PR TITLE
feat: allow loading election definition directly

### DIFF
--- a/src/lib/readFileAsync.ts
+++ b/src/lib/readFileAsync.ts
@@ -1,0 +1,13 @@
+function readFileAsync(file: File) {
+  return new Promise<string>((resolve, reject) => {
+    let reader = new FileReader()
+    reader.onload = () => {
+      const { result } = reader
+      resolve(typeof result === 'string' ? result : '')
+    }
+    reader.onerror = reject
+    reader.readAsText(file)
+  })
+}
+
+export default readFileAsync

--- a/src/screens/LoadElectionScreen.tsx
+++ b/src/screens/LoadElectionScreen.tsx
@@ -164,6 +164,8 @@ const LoadElectionScreen = ({ setElection }: Props) => {
   }
 
   const resetUploadFiles = () => {
+    setInputFiles([])
+    setVxElectionFileIsInvalid(false)
     resetServerFiles()
     updateStatus()
   }
@@ -212,7 +214,9 @@ const LoadElectionScreen = ({ setElection }: Props) => {
                   </p>
                 </FileField>
                 <Button
-                  disabled={!anyFilesExist(inputFiles)}
+                  disabled={
+                    !anyFilesExist(inputFiles) && !vxElectionFileIsInvalid
+                  }
                   small
                   onClick={resetUploadFiles}
                 >

--- a/src/screens/LoadElectionScreen.tsx
+++ b/src/screens/LoadElectionScreen.tsx
@@ -200,7 +200,7 @@ const LoadElectionScreen = ({ setElection }: Props) => {
                     )}
                   </FileField>
                 ))}
-                <p>&ndash; or &ndash;</p>
+                <p>— or —</p>
                 <FileField key="vx-election" htmlFor="vx-election">
                   <h3>Vx Election Definition</h3>
                   {vxElectionFileIsInvalid && <Invalid>Invalid</Invalid>}


### PR DESCRIPTION
Closes #51

Includes `readFileAsync.ts` from #53. The rebase should be painless for whichever doesn't land first.

## New "Vx Election Definition" section

<img width="481" alt="image" src="https://user-images.githubusercontent.com/1938/67037070-ab0b8200-f0d1-11e9-8369-88c83c012fe4.png">

## Loading Invalid File

<img width="480" alt="image" src="https://user-images.githubusercontent.com/1938/67036998-8dd6b380-f0d1-11e9-8833-a4ef476c893e.png">
