### PR TITLE
General Election doesn't have partyId.

### DIFF
--- a/src/screens/TallyScreen.tsx
+++ b/src/screens/TallyScreen.tsx
@@ -104,7 +104,7 @@ const TallyScreen = (props: TallyScreenProps) => {
                 }`
 
                 return (
-                  <React.Fragment key={partyId}>
+                  <React.Fragment key={partyId || 'none'}>
                     <FullTally>
                       <Prose>
                         <h1>Full Election Tally</h1>


### PR DESCRIPTION
This was causing an error in a loop because `key` was undefined. 

In a general election where there are no parties, there is only one set of results… now with the key of `none`.

In a primary, these will be `partyId` values.