### PR TITLE
Enforce CVRs have unique ballotIds.

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -160,7 +160,6 @@ export interface ScreenProps {
 
 // Cast Vote Records
 export interface CastVoteRecordFile {
-  content: string
   name: string
   count: number
   precinctIds: string[]

--- a/src/lib/votecounting.ts
+++ b/src/lib/votecounting.ts
@@ -21,15 +21,15 @@ const writeInCandidate: Candidate = {
 }
 
 // CVRs are newline-separated JSON objects
-export const parseCVRs = (castVoteRecords: string) =>
-  castVoteRecords
+export const parseCVRs = (castVoteRecordsString: string) =>
+  castVoteRecordsString
     .split('\n')
     .filter(el => el) // remove empty lines
     .map(line => JSON.parse(line) as CastVoteRecord)
 
 interface VotesByPrecinctParams {
   election: Election
-  castVoteRecords: string
+  castVoteRecords: CastVoteRecord[]
 }
 
 export function getVotesByPrecinct({
@@ -37,7 +37,7 @@ export function getVotesByPrecinct({
   castVoteRecords,
 }: VotesByPrecinctParams): VotesByPrecinct {
   const votesByPrecinct: VotesByPrecinct = {}
-  parseCVRs(castVoteRecords).forEach(CVR => {
+  castVoteRecords.forEach(CVR => {
     const vote: VotesDict = {}
     election.contests.forEach(contest => {
       if (!CVR[contest.id]) {


### PR DESCRIPTION
This enforces that all CVRs have unique ballotIds. 

It does not inform of duplicate ballots found in the UI to the VxServer user.