### PR TITLE
refactor: extract CVR file handling to its own class

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,8 @@ import React, { useState } from 'react'
 
 import {
   CardData,
-  CastVoteRecord,
   FullElectionTally,
   OptionalElection,
-  CastVoteRecordFilesDictionary,
   VotesByPrecinct,
   ButtonEventFunction,
 } from './config/types'
@@ -24,15 +22,15 @@ import 'normalize.css'
 import './App.css'
 import WritingCardScreen from './screens/WritingCardScreen'
 import ConverterClient from './lib/ConverterClient'
+import CastVoteRecordFiles from './utils/CastVoteRecordFiles'
 
 let loadingElection = false
 
 const App: React.FC = () => {
   const [cardReaderWorking, setCardReaderWorking] = useState(true)
-  const [castVoteRecords, setCastVoteRecords] = useState<CastVoteRecord[]>([])
-  const [castVoteRecordFiles, setCastVoteRecordFiles] = useState<
-    CastVoteRecordFilesDictionary
-  >({})
+  const [castVoteRecordFiles, setCastVoteRecordFiles] = useState(
+    CastVoteRecordFiles.empty
+  )
   const [currentScreen, setCurrentScreen] = useState('')
   const [election, setElection] = useStateAndLocalStorage<OptionalElection>(
     'election'
@@ -45,7 +43,7 @@ const App: React.FC = () => {
 
   const unconfigure = () => {
     setCardReaderWorking(false)
-    setCastVoteRecordFiles({})
+    setCastVoteRecordFiles(CastVoteRecordFiles.empty)
     setCurrentScreen('')
     setElection(undefined)
     setFullElectionTally(undefined)
@@ -121,7 +119,7 @@ const App: React.FC = () => {
   }
 
   const exportResults = async () => {
-    const CastVoteRecordsString = castVoteRecords
+    const CastVoteRecordsString = castVoteRecordFiles.castVoteRecords
       .map(c => JSON.stringify(c))
       .join('\n')
 
@@ -202,11 +200,9 @@ const App: React.FC = () => {
     return (
       <DashboardScreen
         castVoteRecordFiles={castVoteRecordFiles}
-        castVoteRecords={castVoteRecords}
         election={election}
         programCard={programCard}
         setCastVoteRecordFiles={setCastVoteRecordFiles}
-        setCastVoteRecords={setCastVoteRecords}
         setCurrentScreen={setCurrentScreen}
         setFullElectionTally={setFullElectionTally}
         setVotesByPrecinct={setVotesByPrecinct}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,11 @@ import React, { useState } from 'react'
 
 import {
   CardData,
+  CastVoteRecord,
   FullElectionTally,
   OptionalElection,
   CastVoteRecordFilesDictionary,
   VotesByPrecinct,
-  CastVoteRecordFile,
   ButtonEventFunction,
 } from './config/types'
 
@@ -29,6 +29,7 @@ let loadingElection = false
 
 const App: React.FC = () => {
   const [cardReaderWorking, setCardReaderWorking] = useState(true)
+  const [castVoteRecords, setCastVoteRecords] = useState<CastVoteRecord[]>([])
   const [castVoteRecordFiles, setCastVoteRecordFiles] = useState<
     CastVoteRecordFilesDictionary
   >({})
@@ -120,14 +121,9 @@ const App: React.FC = () => {
   }
 
   const exportResults = async () => {
-    // combine CVR data
-    const files = Object.values(castVoteRecordFiles) as CastVoteRecordFile[]
-    const cvrs = files.reduce(
-      (memo, file) =>
-        memo +
-        (!memo || memo.endsWith('\n') ? file.content : `\n${file.content}`),
-      ''
-    )
+    const CastVoteRecordsString = castVoteRecords
+      .map(c => JSON.stringify(c))
+      .join('\n')
 
     // process on the server
     const client = new ConverterClient('results')
@@ -141,7 +137,10 @@ const App: React.FC = () => {
         type: 'application/json',
       })
     )
-    await client.setInputFile(cvrFile.name, new File([cvrs], 'cvrs'))
+    await client.setInputFile(
+      cvrFile.name,
+      new File([CastVoteRecordsString], 'cvrs')
+    )
     await client.process()
 
     // download the result
@@ -203,9 +202,11 @@ const App: React.FC = () => {
     return (
       <DashboardScreen
         castVoteRecordFiles={castVoteRecordFiles}
+        castVoteRecords={castVoteRecords}
         election={election}
         programCard={programCard}
         setCastVoteRecordFiles={setCastVoteRecordFiles}
+        setCastVoteRecords={setCastVoteRecords}
         setCurrentScreen={setCurrentScreen}
         setFullElectionTally={setFullElectionTally}
         setVotesByPrecinct={setVotesByPrecinct}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -163,7 +163,6 @@ export interface ScreenProps {
 
 // Cast Vote Records
 export interface CastVoteRecordFile {
-  content: string
   name: string
   count: number
   precinctIds: string[]

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-cycle
+import CastVoteRecordFiles from '../utils/CastVoteRecordFiles'
+
 // Generic
 export interface Dictionary<T> {
   [key: string]: T | undefined
@@ -163,11 +166,11 @@ export interface ScreenProps {
 
 // Cast Vote Records
 export interface CastVoteRecordFile {
-  name: string
-  count: number
-  precinctIds: string[]
+  readonly name: string
+  readonly count: number
+  readonly precinctIds: readonly string[]
 }
 export type CastVoteRecordFilesDictionary = Dictionary<CastVoteRecordFile>
 export type SetCastVoteRecordFilesFunction = React.Dispatch<
-  React.SetStateAction<Dictionary<CastVoteRecordFile>>
+  React.SetStateAction<CastVoteRecordFiles>
 >

--- a/src/lib/votecounting.ts
+++ b/src/lib/votecounting.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import {
   Candidate,
   CastVoteRecord,

--- a/src/lib/votecounting.ts
+++ b/src/lib/votecounting.ts
@@ -21,15 +21,15 @@ const writeInCandidate: Candidate = {
 }
 
 // CVRs are newline-separated JSON objects
-export const parseCVRs = (castVoteRecords: string) =>
-  castVoteRecords
+export const parseCVRs = (castVoteRecordsString: string) =>
+  castVoteRecordsString
     .split('\n')
     .filter(el => el) // remove empty lines
     .map(line => JSON.parse(line) as CastVoteRecord)
 
 interface VotesByPrecinctParams {
   election: Election
-  castVoteRecords: string
+  castVoteRecords: CastVoteRecord[]
 }
 
 export function getVotesByPrecinct({
@@ -37,7 +37,7 @@ export function getVotesByPrecinct({
   castVoteRecords,
 }: VotesByPrecinctParams): VotesByPrecinct {
   const votesByPrecinct: VotesByPrecinct = {}
-  parseCVRs(castVoteRecords).forEach(CVR => {
+  castVoteRecords.forEach(CVR => {
     const vote: VotesDict = {}
     election.contests.forEach(contest => {
       if (!CVR[contest.id]) {

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -63,14 +63,12 @@ const DashboardScreen = ({
   }
 
   const processCastVoteRecordFiles: InputEventFunction = async event => {
-    // incorporate new CVR
     const input = event.currentTarget
     const files = Array.from(input.files || [])
     const newCastVoteRecordFiles = await castVoteRecordFiles.addAll(files)
 
     setCastVoteRecordFiles(newCastVoteRecordFiles)
 
-    // tally votes
     const vbp = getVotesByPrecinct({
       election,
       castVoteRecords: newCastVoteRecordFiles.castVoteRecords,
@@ -80,7 +78,6 @@ const DashboardScreen = ({
     const ft = fullTallyVotes({ election, votesByPrecinct: vbp })
     setFullElectionTally(ft)
 
-    // reset input
     input.value = ''
   }
 

--- a/src/utils/CastVoteRecordFiles.ts
+++ b/src/utils/CastVoteRecordFiles.ts
@@ -1,0 +1,197 @@
+import arrayUnique from 'array-unique'
+import md5 from 'md5'
+// eslint-disable-next-line import/no-cycle
+import { CastVoteRecord, CastVoteRecordFile } from '../config/types'
+import readFileAsync from '../lib/readFileAsync'
+// eslint-disable-next-line import/no-cycle
+import { parseCVRs } from '../lib/votecounting'
+
+/**
+ * Adds elements to a set by creating a new set with the contents of the
+ * original as well as the new ones. The original set is not modified.
+ *
+ * @example
+ *
+ * const set = new Set([1, 2, 3])
+ * setAdd(set, 4, 5) // Set { 1, 2, 3, 4, 5 }
+ * setAdd(set, 6, 7) // Set { 1, 2, 3, 6, 7 }
+ * set               // Set { 1, 2, 3 }
+ */
+function setAdd<T>(set: Set<T>, ...values: T[]): Set<T> {
+  return new Set([...set, ...values])
+}
+
+/**
+ * Adds values to a map by creating a new map with the contents of the
+ * original as well as the new ones. Keys are provided by `keyfn` which should
+ * map values to a key.
+ *
+ * @example
+ *
+ * const map = new Map([[1, { id: 1 }]])
+ * mapAdd(map, value => value.id, { id: 2 }) // Map { 1 => { id: 1 }, 2 => { id: 2 } }
+ * mapAdd(map, value => value.id, { id: 3 }) // Map { 1 => { id: 1 }, 3 => { id: 3 } }
+ * map                                       // Map { 1 => { id: 1 } }
+ */
+function mapAdd<K, V>(
+  map: Map<K, V>,
+  keyfn: (value: V) => K,
+  ...values: V[]
+): Map<K, V> {
+  const result = new Map(map)
+
+  for (const value of values) {
+    result.set(keyfn(value), value)
+  }
+
+  return result
+}
+
+/**
+ * Tracks files containing cast vote records (CVRs). Has special handling for
+ * duplicate files, files that fail to parse as CVRs, etc.
+ *
+ * Instances of this class are immutable, so all methods that would change the
+ * data simply return a new instance. The constructor is private, so start with
+ * `CastVoteRecordFiles.empty` and "mutate" from there.
+ *
+ * @example
+ *
+ * const cvrFiles = CastVoteRecordFiles.empty.addAll(
+ *   [file1, file1, file2, badFile]
+ * )
+ *
+ * cvrFiles.fileList.map(file => file.name) // ['file1.txt', 'file2.txt']
+ * cvrFiles.duplicateFiles                  // ['file1.txt']
+ * cvrFiles.errorFile                       // 'badfile.txt'
+ * cvrFiles.castVoteRecords                 // […]
+ */
+export default class CastVoteRecordFiles {
+  private readonly signatures: Set<string>
+  private readonly files: Set<CastVoteRecordFile>
+  private readonly duplicateFilenames: Set<string>
+  private readonly parseFailedFilenames: Set<string>
+  private readonly allCastVoteRecords: Map<string, CastVoteRecord>
+
+  /**
+   * This is your starting point for working with this class as the constructor
+   * is private. Build new instances from this starting point.
+   */
+  public static readonly empty = new CastVoteRecordFiles(
+    new Set(),
+    new Set(),
+    new Set(),
+    new Set(),
+    new Map()
+  )
+
+  /**
+   * This is private. Use `CastVoteRecordFiles.empty` then call `add(file)` or
+   * `addAll(files)`.
+   */
+  private constructor(
+    signatures: Set<string>,
+    files: Set<CastVoteRecordFile>,
+    duplicateFilesnames: Set<string>,
+    parseFailedFilenames: Set<string>,
+    castVoteRecords: Map<string, CastVoteRecord>
+  ) {
+    this.signatures = signatures
+    this.files = files
+    this.duplicateFilenames = duplicateFilesnames
+    this.parseFailedFilenames = parseFailedFilenames
+    this.allCastVoteRecords = castVoteRecords
+  }
+
+  /**
+   * Builds a new `CastVoteRecordFiles` object by adding the parsed CVRs from
+   * `files` to those contained by this `CastVoteRecordFiles` instance.
+   */
+  public async addAll(files: File[]): Promise<CastVoteRecordFiles> {
+    let result: CastVoteRecordFiles = this
+
+    for (const file of files) {
+      result = await result.add(file)
+    }
+
+    return result
+  }
+
+  /**
+   * Builds a new `CastVoteRecordFiles` object by adding the parsed CVRs from
+   * `file` to those contained by this `CastVoteRecordFiles` instance.
+   */
+  public async add(file: File): Promise<CastVoteRecordFiles> {
+    try {
+      const fileContent = await readFileAsync(file)
+      const signature = md5(fileContent)
+
+      if (this.signatures.has(signature)) {
+        return new CastVoteRecordFiles(
+          this.signatures,
+          this.files,
+          setAdd(this.duplicateFilenames, file.name),
+          this.parseFailedFilenames,
+          this.allCastVoteRecords
+        )
+      }
+
+      const fileCastVoteRecords = parseCVRs(fileContent)
+      const precinctIds = arrayUnique(
+        fileCastVoteRecords.map(cvr => cvr._precinctId)
+      )
+
+      return new CastVoteRecordFiles(
+        setAdd(this.signatures, signature),
+        setAdd(this.files, {
+          name: file.name,
+          count: fileCastVoteRecords.length,
+          precinctIds,
+        }),
+        this.duplicateFilenames,
+        this.parseFailedFilenames,
+        mapAdd(
+          this.allCastVoteRecords,
+          cvr => cvr._ballotId,
+          ...fileCastVoteRecords
+        )
+      )
+    } catch (error) {
+      return new CastVoteRecordFiles(
+        this.signatures,
+        this.files,
+        this.duplicateFilenames,
+        setAdd(this.parseFailedFilenames, file.name),
+        this.allCastVoteRecords
+      )
+    }
+  }
+
+  /**
+   * The last filename that failed to add.
+   */
+  public get errorFile(): string | undefined {
+    return [...this.parseFailedFilenames].pop()
+  }
+
+  /**
+   * All the added CVR files.
+   */
+  public get fileList(): CastVoteRecordFile[] {
+    return [...this.files]
+  }
+
+  /**
+   * Names of the files that have been added more than once.
+   */
+  public get duplicateFiles(): string[] {
+    return [...this.duplicateFilenames]
+  }
+
+  /**
+   * All parsed CVRs from the added files.
+   */
+  public get castVoteRecords(): CastVoteRecord[] {
+    return [...this.allCastVoteRecords.values()]
+  }
+}

--- a/src/utils/CastVoteRecordsData.test.ts
+++ b/src/utils/CastVoteRecordsData.test.ts
@@ -1,0 +1,63 @@
+import CastVoteRecordFiles from './CastVoteRecordFiles'
+
+test('adds a single CVR file', async () => {
+  const file = new File(['{"_ballotId": "1", "_precinctId": "23"}'], 'cvrs.txt')
+  const cvrFiles = await CastVoteRecordFiles.empty.add(file)
+
+  expect(cvrFiles.fileList).toEqual([
+    { name: 'cvrs.txt', count: 1, precinctIds: ['23'] },
+  ])
+})
+
+test('adds multiple CVR files', async () => {
+  const file1 = new File(
+    ['{"_ballotId": "1", "_precinctId": "23"}'],
+    'cvrs1.txt'
+  )
+  const file2 = new File(
+    [
+      '{"_ballotId": "2", "_precinctId": "23"}\n{"_ballotId": "3", "_precinctId": "23"}',
+    ],
+    'cvrs2.txt'
+  )
+  const cvrFiles = await CastVoteRecordFiles.empty.addAll([file1, file2])
+
+  expect(cvrFiles.fileList).toEqual([
+    { name: 'cvrs1.txt', count: 1, precinctIds: ['23'] },
+    { name: 'cvrs2.txt', count: 2, precinctIds: ['23'] },
+  ])
+})
+
+test('adds duplicated files to the `duplicatedFiles` property', async () => {
+  const file = new File(['{"_ballotId": "1"}'], 'cvrs.txt')
+  const cvrFiles = await CastVoteRecordFiles.empty.addAll([file, file])
+
+  expect(cvrFiles.duplicateFiles).toEqual(['cvrs.txt'])
+})
+
+test('records the last file that fails to parse', async () => {
+  const file = new File(['I am not JSON'], 'not-json.txt')
+  const cvrFiles = await CastVoteRecordFiles.empty.add(file)
+
+  expect(cvrFiles.errorFile).toEqual('not-json.txt')
+})
+
+test('records all parsed cast vote records', async () => {
+  const file1 = new File(
+    ['{"_ballotId": "1", "_precinctId": "23"}'],
+    'cvrs1.txt'
+  )
+  const file2 = new File(
+    [
+      '{"_ballotId": "2", "_precinctId": "23"}\n{"_ballotId": "3", "_precinctId": "24"}',
+    ],
+    'cvrs2.txt'
+  )
+  const cvrFiles = await CastVoteRecordFiles.empty.addAll([file1, file2])
+
+  expect(cvrFiles.castVoteRecords).toEqual([
+    { _ballotId: '1', _precinctId: '23' },
+    { _ballotId: '2', _precinctId: '23' },
+    { _ballotId: '3', _precinctId: '24' },
+  ])
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5"
+    "target": "es2015"
   },
   "exclude": ["src/setupProxy.js"],
   "include": ["src"]


### PR DESCRIPTION
This extracts the CVR handling to its own class (with tests!). It _should_ address @benadida's comment about performance since I'm storing ballots in a `Map` from ballot ID to CVR.