### PR TITLE
accept */* by default, as our CVR files are weird file types anyways.

### DIFF
--- a/src/components/FileInputButton.tsx
+++ b/src/components/FileInputButton.tsx
@@ -31,7 +31,7 @@ interface Props extends HiddenFileInputProps {
 }
 
 const FileInputButton = ({
-  accept = 'text/plain',
+  accept = '*/*',
   buttonProps,
   children,
   id,

--- a/src/screens/LoadElectionScreen.tsx
+++ b/src/screens/LoadElectionScreen.tsx
@@ -182,6 +182,7 @@ const LoadElectionScreen = ({ setElection }: Props) => {
                     }}
                     id="vx-election"
                     name="vx-election"
+                    accept=".json,application/json"
                     onChange={handleVxElectionFile}
                   >
                     Vx Election Definition file


### PR DESCRIPTION
specify .json for election files since we know what those should be.