### PR TITLE
poll when there's no election loaded and card reader is working.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,6 @@ const App: React.FC = () => {
   const [votesByPrecinct, setVotesByPrecinct] = useState<VotesByPrecinct>({})
 
   const unconfigure = () => {
-    setCardReaderWorking(false)
     setCastVoteRecordFiles(CastVoteRecordFiles.empty)
     setCurrentScreen('')
     setPrecinctIdTallyFilter('')
@@ -165,7 +164,7 @@ const App: React.FC = () => {
           setCardReaderWorking(false)
         })
     },
-    cardReaderWorking ? 1000 : undefined
+    cardReaderWorking && !election ? 1000 : undefined
   )
 
   if (election) {


### PR DESCRIPTION
When unconfiguring an election, the screen switched to the ability to upload files, but there is no longer a way to load a new election via a card, because polling is disabled. This PR fixes that.

I've manually tested that writing admin and poll worker cards still works.